### PR TITLE
Omnibus Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ pip install py-jama-client
 #### Basic
 
 ```python
-from py_jama_rest_client.client import JamaClient # import client
-from py_jama_rest_client.apis.abstract_items_api import AbstractItemsAPI # import API
+from py_jama_client.client import JamaClient # import client
+from py_jama_client.apis.abstract_items_api import AbstractItemsAPI # import API
 
 client = JamaClient(
     host="example.jamacloud.com", 
@@ -45,8 +45,8 @@ print(abstract_items.data)
 #### With Links
 
 ```python
-from py_jama_rest_client.client import JamaClient # import client
-from py_jama_rest_client.apis.items_api import ItemsAPI # import API
+from py_jama_client.client import JamaClient # import client
+from py_jama_client.apis.items_api import ItemsAPI # import API
 
 client = JamaClient(
     host="example.jamacloud.com", 

--- a/py_jama_client/__about__.py
+++ b/py_jama_client/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.1"
+VERSION = "0.1.0"

--- a/py_jama_client/apis/abstract_items_api.py
+++ b/py_jama_client/apis/abstract_items_api.py
@@ -187,7 +187,7 @@ class AbstractItemsAPI:
             **kwargs,
         )
 
-    def get_abtract_item_version(
+    def get_abstract_item_version(
         self,
         item_id: int,
         version_num: int,

--- a/py_jama_client/apis/abstract_items_api.py
+++ b/py_jama_client/apis/abstract_items_api.py
@@ -179,7 +179,7 @@ class AbstractItemsAPI:
 
         Returns: JSON array with all versions for the item
         """
-        resource_path = f"abstractitems/{item_id}/versions"
+        resource_path = f"{self.resource_path}/{item_id}/versions"
         return self.client.get_all(
             resource_path,
             params,
@@ -203,7 +203,7 @@ class AbstractItemsAPI:
             item_id: the item id of the item to fetch
             version_num: the version number for the item
         """
-        resource_path = f"abstractitems/{item_id}/versions/{version_num}"
+        resource_path = f"{self.resource_path}/{item_id}/versions/{version_num}"
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
@@ -228,7 +228,7 @@ class AbstractItemsAPI:
             item_id: the item id of the item to fetch
             version_num: the version number for the item
         """
-        resource_path = f"abstractitems/{item_id}/versions/{version_num}/versioneditem"
+        resource_path = f"{self.resource_path}/{item_id}/versions/{version_num}/versioneditem"
         try:
             response = self.client.get(resource_path, params, **kwargs)
         except CoreException as err:

--- a/py_jama_client/apis/abstract_items_api.py
+++ b/py_jama_client/apis/abstract_items_api.py
@@ -17,7 +17,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class AbstractItemsAPI:

--- a/py_jama_client/apis/abstract_items_api.py
+++ b/py_jama_client/apis/abstract_items_api.py
@@ -3,7 +3,7 @@ Abstract Items API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> abstract_items_api = AbstractItemsAPI(client)
     >>> abstract_items = abstract_items_api.get_abstract_items()

--- a/py_jama_client/apis/abstract_items_api.py
+++ b/py_jama_client/apis/abstract_items_api.py
@@ -116,7 +116,7 @@ class AbstractItemsAPI:
     ):
         """
         Get any item, test plan, test cycle, test run, or attachment with the specified ID
-        GET: /abstractitems/{id}
+        GET: /abstractitems/{item_id}
 
         Args:
             item_id: the item id of the item to fetch
@@ -141,10 +141,10 @@ class AbstractItemsAPI:
     ):
         """
         Get all versioned relationships that were associated to the item at the specified time
-        GET: /abstractitems/{id}/versionedrelationships
+        GET: /abstractitems/{item_id}/versionedrelationships
 
         Args:
-            id: item resource id
+            item_id: item resource id
             timestamp: Get relationships for the specified item at this date and time.
                 Requires ISO8601 formatting (milliseconds or seconds) - "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
                 or "yyyy-MM-dd'T'HH:mm:ssZ"
@@ -172,7 +172,7 @@ class AbstractItemsAPI:
     ):
         """
         Get all versions for the item with the specified ID
-        GET: /abstractitems/{id}/versions
+        GET: /abstractitems/{item_id}/versions
 
         Args:
             item_id: the item id of the item to fetch
@@ -197,7 +197,7 @@ class AbstractItemsAPI:
     ):
         """
         Get the numbered version for the item with the specified ID
-        GET: /abstractitems/{id}/versions/{versionNum}/
+        GET: /abstractitems/{item_id}/versions/{version_num}/
 
         Args:
             item_id: the item id of the item to fetch
@@ -222,7 +222,7 @@ class AbstractItemsAPI:
     ):
         """
         Get the snapshot of the item at the specified version
-        GET: /abstractitems/{id}/versions/{versionNum}/versioneditem/
+        GET: /abstractitems/{item_id}/versions/{version_num}/versioneditem/
 
         Args:
             item_id: the item id of the item to fetch

--- a/py_jama_client/apis/activities_api.py
+++ b/py_jama_client/apis/activities_api.py
@@ -17,7 +17,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class ActivitiesAPI:

--- a/py_jama_client/apis/activities_api.py
+++ b/py_jama_client/apis/activities_api.py
@@ -3,7 +3,7 @@ Activities API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> activities_api = ActivitiesAPI(client)
     >>> activities = activities_api.get_activities(project_id=82)

--- a/py_jama_client/apis/activities_api.py
+++ b/py_jama_client/apis/activities_api.py
@@ -47,17 +47,25 @@ class ActivitiesAPI:
 
         Args:
             project_id: Project resource id
-            event_type: Event type to filter on. More than one event type can be chosen
-                Available values : CREATE, BATCH_CREATE, UPDATE, BATCH_UPDATE, DELETE, BATCH_DELETE,
-                PUBLIC, BATCH_SUMMARY, COPY, BATCH_COPY, MOVE, APPLY, MERGE, CREATE_INSTANCE, EDIT,
-                EDIT_PROJECT, REMOVE_INSTANCE, REMOVE
-            object_type: Object type to filter on. More than one object type can be chosen
-                Available values : PROJECT, ITEM, USER, RELATIONSHIP, COMMENT, ITEM_TAG, TAG, ITEM_ATTACHMENT,
-                URL, TEST_RESULT, BASELINE, CHANGE_REQUEST, REVIEW, REVISION, REVISION_ITEM, TEST_PLAN, TEST_CYCLE,
-                TEST_RUN, INTEGRATION, MISCELLANEOUS, CATEGORY, CATEGORIZED_ITEM, CATEGORY_PATH
-            item_type: ID of item type to filter on. More than one item type can be chosen
-            date: Filter datetime fields after a single date or within a range of values. Provide one or two values
-                in ISO8601 format (milliseconds or seconds) - "yyyy-MM-dd'T'HH:mm:ss.SSSZ" or "yyyy-MM-dd'T'HH:mm:ssZ"
+            event_type: Event type to filter on. More than one event type can
+                be chosen
+                Available values : CREATE, BATCH_CREATE, UPDATE, BATCH_UPDATE,
+                DELETE, BATCH_DELETE, PUBLIC, BATCH_SUMMARY, COPY, BATCH_COPY,
+                MOVE, APPLY, MERGE, CREATE_INSTANCE, EDIT, EDIT_PROJECT,
+                REMOVE_INSTANCE, REMOVE
+            object_type: Object type to filter on. More than one object type
+                can be chosen
+                Available values : PROJECT, ITEM, USER, RELATIONSHIP, COMMENT,
+                ITEM_TAG, TAG, ITEM_ATTACHMENT, URL, TEST_RESULT, BASELINE,
+                CHANGE_REQUEST, REVIEW, REVISION, REVISION_ITEM, TEST_PLAN,
+                TEST_CYCLE, TEST_RUN, INTEGRATION, MISCELLANEOUS, CATEGORY,
+                CATEGORIZED_ITEM, CATEGORY_PATH
+            item_type: ID of item type to filter on. More than one item type
+                can be chosen
+            date: Filter datetime fields after a single date or within a range
+                of values. Provide one or two values in ISO8601 format
+                (milliseconds or seconds)
+                - "yyyy-MM-dd'T'HH:mm:ss.SSSZ" or "yyyy-MM-dd'T'HH:mm:ssZ"
             delete_events: Get item delete events only
         """
         req_params = {"project": project_id}
@@ -142,7 +150,8 @@ class ActivitiesAPI:
         Args:
             activity_id: (int) activity resource id
         """
-        resource_path = f"{self.resource_path}/activities/{activity_id}/restore"
+        resource_path = (
+            f"{self.resource_path}/activities/{activity_id}/restore")
         try:
             response = self.client.post(
                 resource_path,
@@ -170,9 +179,11 @@ class ActivitiesAPI:
 
         Args:
             filter_term: (str) Filter on the text contents of the activities.
-                Strings in quotations taken literally.
-                Multiple values will be treated as separate tokens for matching.
-            project_id: (int) Filter by Project ID. User must be at least Project Administrator
+                         - Strings in quotations taken literally.
+                         - Multiple values are treated as separate tokens
+                                for matching.
+            project_id: (int) Filter by Project ID. User must be at least
+                        Project Administrator
         """
         if params is None:
             params = {}

--- a/py_jama_client/apis/attachments_api.py
+++ b/py_jama_client/apis/attachments_api.py
@@ -95,7 +95,8 @@ class AttachmentsAPI:
         PUT: /attachments/{attachmentId}/file
 
         Args:
-            attachment_id: the integer ID of the attachment item to which we are uploading the file
+            attachment_id: the integer ID of the attachment item to which we
+                are uploading the file
             file_path: the file path of the file to be uploaded
         """
         resource_path = f"attachments/{attachment_id}/file"
@@ -122,7 +123,8 @@ class AttachmentsAPI:
         **kwargs,
     ):
         """
-        Get the locked state, last locked date, and last locked by user for the item with the specified ID
+        Get the locked state, last locked date, and last locked by user for
+        the item with the specified ID
         GET: /attachments/{attachmentId}/lock
 
         Args:
@@ -197,7 +199,8 @@ class AttachmentsAPI:
         Get the numbered version for the item with the specified ID
         GET: /attachments/{attachmentId}/versions/{versionNum}
         """
-        resource_path = f"{self.resource_path}/{attachment_id}/versions/{version_num}"
+        resource_path = (
+            f"{self.resource_path}/{attachment_id}/versions/{version_num}")
         try:
             response = self.client.get(resource_path, params, **kwargs)
         except CoreException as err:
@@ -219,7 +222,8 @@ class AttachmentsAPI:
         GET: /attachments/{attachmentId}/versions/{versionNum}/versionedItem
         """
         resource_path = (
-            f"{self.resource_path}/{attachment_id}/versions/{version_num}/versionedItem"
+            f"{self.resource_path}/{attachment_id}/versions/"
+            f"{version_num}/versionedItem"
         )
         try:
             response = self.client.get(resource_path, params, **kwargs)

--- a/py_jama_client/apis/attachments_api.py
+++ b/py_jama_client/apis/attachments_api.py
@@ -3,7 +3,7 @@ Attachments API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> attachments_api = AttachmentsAPI(client)
     >>> attachments = attachments_api.get_attachment(attachment_id=10)

--- a/py_jama_client/apis/attachments_api.py
+++ b/py_jama_client/apis/attachments_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class AttachmentsAPI:

--- a/py_jama_client/apis/baselines_api.py
+++ b/py_jama_client/apis/baselines_api.py
@@ -108,7 +108,8 @@ class BaselinesAPI:
             "baselineStatusPickListOption": baseline_status_pick_list_option,
         }
         try:
-            response = self.client.put(resource_path, data=json.dumps(body) ** kwargs)
+            response = self.client.put(resource_path,
+                                       data=json.dumps(body) ** kwargs)
         except CoreException as err:
             py_jama_client_logger.error(err)
             raise APIException(str(err))
@@ -188,14 +189,16 @@ class BaselinesAPI:
         **kwargs,
     ):
         """
-        Get the baseline item with the specified ID in a baseline with the specified ID
+        Get the baseline item with the specified ID in a baseline with the
+        specified ID
         GET: /baselines/{baselineId}/versioneditems/{itemId}
 
         Args:
             baseline_id: baseline resource id
             item_id: baseline item resource id
         """
-        resource_path = f"{self.resource_path}/{baseline_id}/versioneditems/{item_id}"
+        resource_path = (
+            f"{self.resource_path}/{baseline_id}/versioneditems/{item_id}")
         return self.client.get_all(resource_path, params, **kwargs)
 
     def get_baseline_versioned_item_relationships(
@@ -209,13 +212,16 @@ class BaselinesAPI:
     ):
         """
         Get all versioned relationships for the item in the baseline
-        GET: /baselines/{baselineId}/versioneditems/{itemId}/versionedrelationships
+        GET:
+         /baselines/{baselineId}/versioneditems/{itemId}/versionedrelationships
 
         Args:
             baseline_id: baseline resource id
             item_id: baseline item resource id
         """
-        resource_path = f"{self.resource_path}/{baseline_id}/versioneditems/{item_id}/versionedrelationships"
+        resource_path = (
+            f"{self.resource_path}/{baseline_id}/versioneditems/"
+            f"{item_id}/versionedrelationships")
         return self.client.get_all(
             resource_path, params, allowed_results_per_page, **kwargs
         )

--- a/py_jama_client/apis/baselines_api.py
+++ b/py_jama_client/apis/baselines_api.py
@@ -199,7 +199,13 @@ class BaselinesAPI:
         """
         resource_path = (
             f"{self.resource_path}/{baseline_id}/versioneditems/{item_id}")
-        return self.client.get_all(resource_path, params, **kwargs)
+        try:
+            response = self.client.get(resource_path, params, **kwargs)
+        except CoreException as err:
+            py_jama_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.handle_response_status(response)
+        return ClientResponse.from_response(response)
 
     def get_baseline_versioned_item_relationships(
         self,

--- a/py_jama_client/apis/baselines_api.py
+++ b/py_jama_client/apis/baselines_api.py
@@ -17,7 +17,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_rest_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class BaselinesAPI:
@@ -74,7 +74,7 @@ class BaselinesAPI:
         try:
             response = self.client.get(resource_path, params, **kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -110,7 +110,7 @@ class BaselinesAPI:
         try:
             response = self.client.put(resource_path, data=json.dumps(body) ** kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -132,7 +132,7 @@ class BaselinesAPI:
         try:
             response = self.client.delete(resource_path, **kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
             return JamaClient.handle_response_status(response)
 
@@ -153,7 +153,7 @@ class BaselinesAPI:
         try:
             response = self.client.get(resource_path, **kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)

--- a/py_jama_client/apis/baselines_api.py
+++ b/py_jama_client/apis/baselines_api.py
@@ -1,8 +1,8 @@
 """
-Baseline API module
+Baselines API module
 
 Example usage:
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> baselines_api = BaselinesAPI(client)
     >>> baselines = baselines_api.get_baselines(project_id=82)

--- a/py_jama_client/apis/filters_api.py
+++ b/py_jama_client/apis/filters_api.py
@@ -43,7 +43,8 @@ class FiltersAPI:
 
         Args:
             filter_id: The ID of the filter to fetch the results for.
-            project_id: Use this only for filters that run on any project, where projectScope is CURRENT
+            project_id: Use this only for filters that run on any project,
+                where projectScope is CURRENT
             allowed_results_per_page: Number of results per page
 
         Returns:

--- a/py_jama_client/apis/filters_api.py
+++ b/py_jama_client/apis/filters_api.py
@@ -3,7 +3,7 @@ Filters API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> filters_api = FiltersAPI(client)
     >>> filters = filters_api.get_filter_results()

--- a/py_jama_client/apis/filters_api.py
+++ b/py_jama_client/apis/filters_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class FiltersAPI:

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -37,7 +37,8 @@ class ItemTypesAPI:
         **kwargs,
     ):
         """
-        This method will return all item types of the across all projects of the Jama Connect instance.
+        This method will return all item types of the across all projects of
+        the Jama Connect instance.
 
         Args:
             allowed_results_per_page: Number of results per page

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -70,7 +70,7 @@ class ItemTypesAPI:
         """
         resource_path = f"itemtypes/{item_type_id}"
         try:
-            response = self._core.get(resource_path, params)
+            response = self.client.get(resource_path, params)
         except CoreException as err:
             py_jama_client_logger.error(err)
             raise APIException(str(err))

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -1,9 +1,9 @@
 """
-Relationship API module
+Item Types API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> item_types_api = ItemTypesAPI(client)
     >>> item_types = item_types_api.get_item_types()

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -45,9 +45,8 @@ class ItemTypesAPI:
         Returns: An array of dictionary objects
 
         """
-        resource_path = "itemtypes/"
-        return self.get_all(
-            resource_path,
+        return self.client.get_all(
+            self.resource_path,
             params,
             allowed_results_per_page=allowed_results_per_page,
         )

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class ItemTypesAPI:

--- a/py_jama_client/apis/item_types_api.py
+++ b/py_jama_client/apis/item_types_api.py
@@ -49,6 +49,7 @@ class ItemTypesAPI:
             self.resource_path,
             params,
             allowed_results_per_page=allowed_results_per_page,
+            **kwargs,
         )
 
     def get_item_type(

--- a/py_jama_client/apis/items_api.py
+++ b/py_jama_client/apis/items_api.py
@@ -1,12 +1,12 @@
 """
-User API module
+Items API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
-    >>> item_api = ItemAPI(client)
-    >>> items = projects.get_items(project_id=1)
+    >>> items_api = ItemsAPI(client)
+    >>> items = items_api.get_items(project_id=1)
 """
 
 import json

--- a/py_jama_client/apis/items_api.py
+++ b/py_jama_client/apis/items_api.py
@@ -17,7 +17,7 @@ from py_jama_client.client import ClientResponse, JamaClient
 from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 
-py_jama_rest_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class ItemsAPI:
@@ -77,7 +77,7 @@ class ItemsAPI:
         try:
             response = self.client.get(resource_path, params, **kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -138,7 +138,7 @@ class ItemsAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -168,7 +168,7 @@ class ItemsAPI:
                 resource_path, params, data=json.dumps(body), headers=headers, **kwargs
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return response.status_code
@@ -203,7 +203,7 @@ class ItemsAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -234,7 +234,7 @@ class ItemsAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return response.status_code
@@ -280,7 +280,7 @@ class ItemsAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         self.handle_response_status(response)
         return response.status_code
@@ -321,7 +321,7 @@ class ItemsAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
 
         JamaClient.handle_response_status(response)
@@ -345,7 +345,7 @@ class ItemsAPI:
         try:
             response = self.client.delete(resource_path)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return response.status_code
@@ -555,7 +555,7 @@ class ItemsAPI:
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -599,7 +599,7 @@ class ItemsAPI:
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -625,7 +625,7 @@ class ItemsAPI:
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -710,7 +710,7 @@ class ItemsAPI:
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -738,7 +738,7 @@ class ItemsAPI:
                 headers=headers,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         return self.handle_response_status(response)
 

--- a/py_jama_client/apis/items_api.py
+++ b/py_jama_client/apis/items_api.py
@@ -165,7 +165,11 @@ class ItemsAPI:
         headers = {"content-type": "application/json"}
         try:
             response = self.client.post(
-                resource_path, params, data=json.dumps(body), headers=headers, **kwargs
+                resource_path,
+                params,
+                data=json.dumps(body),
+                headers=headers,
+                **kwargs
             )
         except CoreException as err:
             py_jama_client_logger.error(err)
@@ -184,8 +188,8 @@ class ItemsAPI:
         """
         add an item to an existing pool of global ids
         Args:
-            source_item: integer API ID of the source item, this item will adopt the global id of the
-                         pool_item.
+            source_item: integer API ID of the source item, this item will
+                adopt the global id of the pool_item.
             pool_item: integer API ID of the item in the target global ID pool.
 
         Returns: the integer ID of the modified source item.
@@ -251,15 +255,19 @@ class ItemsAPI:
         params: Optional[dict] = None,
         **kwargs,
     ):
-        """This method wil
-         PUT a new item to Jama Connect.
-        :param project integer representing the project to which this item is to be posted
-        :param item_id integer representing the item which is to be updated
-        :param item_type_id integer ID of an Item Type.
-        :param child_item_type_id integer ID of an Item Type.
-        :param location dictionary  with a key of 'item' or 'project' and an value with the ID of the parent
-        :param fields dictionary item field data.
-        :return integer ID of the successfully posted item or None if there was an error.
+        """
+        This method will PUT a new item to Jama Connect.
+        Args:
+            project: integer representing the project to which this item is to
+                be posted
+            item_id: integer representing the item which is to be updated
+            item_type_id: integer ID of an Item Type.
+            child_item_type_id: integer ID of an Item Type.
+            location: dictionary with a key of 'item' or 'project' and a value
+                with the ID of the parent
+            fields: dictionary item field data.
+        Returns: integer ID of the successfully posted item or None if there
+        was an error.
         """
 
         body = {
@@ -297,7 +305,8 @@ class ItemsAPI:
         This method will patch an item.
         Args:
             item_id: the API ID of the item that is to be patched
-            patches: An array of dicts, that represent patch operations each dict should have the following entries
+            patches: An array of dicts, that represent patch operations each
+                dict should have the following entries
              [
                 {
                     "op": string,
@@ -310,7 +319,8 @@ class ItemsAPI:
 
         """
         resource_path = f"items/{item_id}"
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {"Content-Type": "application/json",
+                   "Accept": "application/json"}
 
         try:
             response = self.client.patch(
@@ -386,12 +396,14 @@ class ItemsAPI:
         **kwargs,
     ):
         """
-        Returns a list of all the upstream relationships for the item with the specified ID.
+        Returns a list of all the upstream relationships for the item with the
+        specified API ID.
         Args:
             item_id: the api id of the item
             allowed_results_per_page: number of results per page
 
-        Returns: an array of dictionary objects that represent the upstream relationships for the item.
+        Returns: an array of dictionary objects that represent the upstream
+        relationships for the item.
 
         """
         resource_path = "items/" + str(item_id) + "/upstreamrelationships"
@@ -411,13 +423,15 @@ class ItemsAPI:
         **kwargs,
     ):
         """
-        Returns a list of all the downstream related items for the item with the specified ID.
+        Returns a list of all the downstream related items for the item with
+        the specified API ID.
 
         Args:
             item_id: the api id of the item to fetch downstream items for
             allowed_results_per_page: number of results per page
 
-        Returns: an array of dictionary objects that represent the downstream related items for the specified item.
+        Returns: an array of dictionary objects that represent the downstream
+        related items for the specified item.
 
         """
         resource_path = f"items/{item_id}/downstreamrelated"
@@ -437,12 +451,14 @@ class ItemsAPI:
         **kwargs,
     ):
         """
-        Returns a list of all the downstream relationships for the item with the specified ID.
+        Returns a list of all the downstream relationships for the item with
+        the specified API ID.
 
         Args:
             item_id: the api id of the item
 
-        Returns: an array of dictionary objects that represent the downstream relationships for the item.
+        Returns: an array of dictionary objects that represent the downstream
+        relationships for the item.
 
         """
         resource_path = f"items/{item_id}/downstreamrelationships"
@@ -454,12 +470,14 @@ class ItemsAPI:
         self, item_id: int, *args, params: Optional[dict] = None, **kwargs
     ):
         """
-        Returns a list of all the upstream related items for the item with the specified ID.
+        Returns a list of all the upstream related items for the item with the
+        specified API ID.
 
         Args:
             item_id: the api id of the item to fetch upstream items for
 
-        Returns: an array of dictionary objects that represent the upstream related items for the specified item.
+        Returns: an array of dictionary objects that represent the upstream
+        related items for the specified item.
 
         """
         resource_path = f"items/{item_id}/upstreamrelated"
@@ -473,13 +491,15 @@ class ItemsAPI:
         **kwargs,
     ):
         """
-        Get all valid workflow transitions that can be made with the specified id
+        Get all valid workflow transitions that can be made with the specified
+        API ID
 
         Args:
             item_id: the api id of the item
             allowed_results_per_page: number of results per page
 
-        Returns: an array of dictionary objects that represent the workflow transitions for the item.
+        Returns: an array of dictionary objects that represent the workflow
+        transitions for the item.
 
         """
         resource_path = f"items/{item_id}/workflowtransitionoptions"
@@ -494,12 +514,14 @@ class ItemsAPI:
         **kwargs,
     ):
         """
-        This method will return list of the child items of the item passed to the function.
+        This method will return list of the child items of the item passed to
+        the function.
         Args:
-            item_id: (int) The id of the item for which children items should be fetched
-            allowed_results_per_page: Number of results per page
+            item_id: (int) The id of the item for which children items should
+            be fetched allowed_results_per_page: Number of results per page
 
-        Returns: a List of Objects that represent the children of the item passed in.
+        Returns: a List of Objects that represent the children of the item
+        passed in.
         """
         resource_path = f"items/{item_id}/children"
         return self.client.get_all(
@@ -524,8 +546,8 @@ class ItemsAPI:
             item_id: The API id of the item being
             allowed_results_per_page: Number of results per page
 
-        Returns: A list of JSON Objects representing the items that are in the same synchronization group as the
-        specified item.
+        Returns: A list of JSON Objects representing the items that are in the
+        same synchronization group as the specified item.
 
         """
         resource_path = f"items/{item_id}/synceditems"
@@ -548,10 +570,12 @@ class ItemsAPI:
             item_id: The id of the item to compare against
             synced_item_id: the id of the item to check if it is in sync
 
-        Returns: The response JSON from the API which contains a single field 'inSync' with a boolean value.
+        Returns: The response JSON from the API which contains a single field
+            'inSync' with a boolean value.
 
         """
-        resource_path = f"items/{item_id}/synceditems/{synced_item_id}/syncstatus"
+        resource_path = (
+            f"items/{item_id}/synceditems/{synced_item_id}/syncstatus")
         try:
             response = self.client.get(resource_path, params)
         except CoreException as err:
@@ -649,7 +673,9 @@ class ItemsAPI:
         """
         resource_path = f"items/{item_id}/versions"
         return self.client.get_all(
-            resource_path, params, allowed_results_per_page=allowed_results_per_page
+            resource_path,
+            params,
+            allowed_results_per_page=allowed_results_per_page
         )
 
     def get_item_version(
@@ -698,12 +724,14 @@ class ItemsAPI:
 
     def get_item_lock(self, item_id: int, params: Optional[dict] = None):
         """
-        Get the locked state, last locked date, and last locked by user for the item with the specified ID
+        Get the locked state, last locked date, and last locked by user for
+        the item with the specified ID
         Args:
             item_id: The API ID of the item to get the lock info for.
 
         Returns:
-            A JSON object with the lock information for the item with the specified ID.
+            A JSON object with the lock information for the item with the
+            specified ID.
 
         """
         resource_path = f"items/{item_id}/lock"

--- a/py_jama_client/apis/pick_list_options_api.py
+++ b/py_jama_client/apis/pick_list_options_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class PickListOptionsAPI:

--- a/py_jama_client/apis/pick_list_options_api.py
+++ b/py_jama_client/apis/pick_list_options_api.py
@@ -3,7 +3,7 @@ Pick List Options API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> pick_list_options_api = PickListOptionsAPI(client)
     >>> pick_list_options = pick_list_options_api.get_pick_list_options(pick_list_id=10)

--- a/py_jama_client/apis/pick_list_options_api.py
+++ b/py_jama_client/apis/pick_list_options_api.py
@@ -6,7 +6,8 @@ Example usage:
     >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> pick_list_options_api = PickListOptionsAPI(client)
-    >>> pick_list_options = pick_list_options_api.get_pick_list_options(pick_list_id=10)
+    >>> pick_list_options = pick_list_options_api.get_pick_list_options(
+            pick_list_id=10)
 """
 
 import json

--- a/py_jama_client/apis/pick_lists_api.py
+++ b/py_jama_client/apis/pick_lists_api.py
@@ -88,10 +88,12 @@ class PickListsAPI:
             pick_list_id: the api id of the picklist to fetch options for.
             allowed_results_per_page: number of results per page
 
-        Returns: an array of dictionary objects that represent the picklist options.
-
+        Returns: an array of dictionary objects that represent the
+        picklist options.
         """
         resource_path = f"picklists/{pick_list_id}/options"
         return self.client.get_all(
-            resource_path, params, allowed_results_per_page=allowed_results_per_page
+            resource_path,
+            params,
+            allowed_results_per_page=allowed_results_per_page
         )

--- a/py_jama_client/apis/pick_lists_api.py
+++ b/py_jama_client/apis/pick_lists_api.py
@@ -3,7 +3,7 @@ Pick Lists API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> pick_lists_api = PickListsAPI(client)
     >>> pick_lists = pick_lists_api.get_pick_lists()

--- a/py_jama_client/apis/pick_lists_api.py
+++ b/py_jama_client/apis/pick_lists_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class PickListsAPI:

--- a/py_jama_client/apis/projects_api.py
+++ b/py_jama_client/apis/projects_api.py
@@ -45,10 +45,14 @@ class ProjectsAPI:
         resource_path = "projects"
 
         return self.client.get_all(
-            resource_path, params, allowed_results_per_page=allowed_results_per_page
+            resource_path,
+            params,
+            allowed_results_per_page=allowed_results_per_page
         )
 
-    def get_project_by_id(self, project_id: int, params: Optional[dict] = None):
+    def get_project_by_id(self,
+                          project_id: int,
+                          params: Optional[dict] = None):
         """
         This method will return a single project as JSON object
         Args:
@@ -68,9 +72,11 @@ class ProjectsAPI:
 
     def get_relationship_rule_set_projects(self, id: int):
         """
-        This method will return the projects that have a given relationship rule set defined.
+        This method will return the projects that have a given relationship
+        rule set defined.
 
-        Returns: An array of the dictionary objects representing the projects with a given rule set assigned
+        Returns: An array of the dictionary objects representing the projects
+        with a given rule set assigned
 
         """
         resource_path = f"relationshiprulesets/{id}/projects"
@@ -131,7 +137,8 @@ class ProjectsAPI:
         resource_path = f"projects/{project_id}/itemtypes/{item_type_id}"
         headers = {"content-type": "application/json"}
         try:
-            response = self.client.put(resource_path, params, headers=headers, **kwargs)
+            response = self.client.put(
+                resource_path, params, headers=headers, **kwargs)
         except CoreException as err:
             py_jama_client_logger.error(err)
             raise APIException(str(err))

--- a/py_jama_client/apis/projects_api.py
+++ b/py_jama_client/apis/projects_api.py
@@ -1,9 +1,9 @@
 """
-User API module
+Projects API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> projects_api = ProjectsAPI(client)
     >>> projects = projects_api.get_projects()

--- a/py_jama_client/apis/projects_api.py
+++ b/py_jama_client/apis/projects_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import (APIException, CoreException,
                                        ResourceNotFoundException)
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class ProjectsAPI:

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class RelationshipsAPI:

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -177,6 +177,26 @@ class RelationshipsAPI:
         JamaClient.handle_response_status(response)
         return response.status_code
 
+    def delete_relationship_suspect(self, relationship_id: int) -> int:
+        """
+        Removes suspect status of a relationship with the 
+        specified relationship ID
+
+        Args:
+            relationship_id: the api project id of a relationship
+
+        Returns: The success status code.
+
+        """
+        resource_path = f"relationships/{relationship_id}/suspect"
+        try:
+            response = self.client.delete(resource_path)
+        except CoreException as err:
+            py_jama_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.handle_response_status(response)
+        return response.status_code
+
     def get_relationship_rule_sets(self):
         """
         This method will return all relationship rule sets across all projects of the Jama Connect instance.

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -187,14 +187,14 @@ class RelationshipsAPI:
         resource_path = "relationshiprulesets/"
         return self.client.get_all(resource_path)
 
-    def get_relationship_rule_set(self, id: int):
+    def get_relationship_rule_set(self, relationship_id: int):
         """
         This method will return the relationship rule sets by id.
 
         Returns: A dictionary object representing a rule set and its associated rules
 
         """
-        resource_path = f"relationshiprulesets/{id}"
+        resource_path = f"relationshiprulesets/{relationship_id}"
         response = self.client.get(resource_path)
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -158,7 +158,7 @@ class RelationshipsAPI:
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
 
-    def delete_relationships(self, relationship_id: int) -> int:
+    def delete_relationship(self, relationship_id: int) -> int:
         """
         Deletes a relationship with the specified relationship ID
 

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -1,11 +1,11 @@
 """
-Relationship API module
+Relationships API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
-    >>> relationship_api = RelationshipsAPI(client)
+    >>> relationships_api = RelationshipsAPI(client)
     >>> relationships = relationships_api.get_relationships(project_id=82)
 """
 

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -99,7 +99,8 @@ class RelationshipsAPI:
         Args:
             from_item: integer API id of the source item
             to_item: integer API id of the target item
-            relationship_type: Optional integer API id of the relationship type to create
+            relationship_type: Optional integer API id of the relationship
+                type to create
 
         Returns: The integer ID of the newly created relationship.
 
@@ -141,7 +142,8 @@ class RelationshipsAPI:
             relationship_id: integer API id of the relationship
             from_item: integer API id of the source item
             to_item: integer API id of the target item
-            relationship_type: Optional integer API id of the relationship type to create
+            relationship_type: Optional integer API id of the relationship
+                type to create
         """
         body = {"fromItem": from_item, "toItem": to_item}
         if relationship_type is not None:
@@ -150,7 +152,11 @@ class RelationshipsAPI:
         headers = {"content-type": "application/json"}
         try:
             response = self.client.put(
-                resource_path, params, data=json.dumps(body), headers=headers, **kwargs
+                resource_path,
+                params,
+                data=json.dumps(body),
+                headers=headers,
+                **kwargs
             )
         except CoreException as err:
             py_jama_client_logger.error(err)
@@ -179,7 +185,7 @@ class RelationshipsAPI:
 
     def delete_relationship_suspect(self, relationship_id: int) -> int:
         """
-        Removes suspect status of a relationship with the 
+        Removes suspect status of a relationship with the
         specified relationship ID
 
         Args:
@@ -199,9 +205,11 @@ class RelationshipsAPI:
 
     def get_relationship_rule_sets(self):
         """
-        This method will return all relationship rule sets across all projects of the Jama Connect instance.
+        This method will return all relationship rule sets across all projects
+        of the Jama Connect instance.
 
-        Returns: An array of dictionary objects representing a rule set and its associated rules
+        Returns: An array of dictionary objects representing a rule set and
+        its associated rules
 
         """
         resource_path = "relationshiprulesets/"
@@ -211,7 +219,8 @@ class RelationshipsAPI:
         """
         This method will return the relationship rule sets by id.
 
-        Returns: A dictionary object representing a rule set and its associated rules
+        Returns: A dictionary object representing a rule set and its
+                 associated rules
 
         """
         resource_path = f"relationshiprulesets/{relationship_id}"
@@ -227,7 +236,8 @@ class RelationshipsAPI:
         **kwargs,
     ):
         """
-        This method will return all relationship types of the across all projects of the Jama Connect instance.
+        This method will return all relationship types of the across all
+        projects of the Jama Connect instance.
 
         Args:
             allowed_results_per_page: Number of results per page
@@ -241,7 +251,11 @@ class RelationshipsAPI:
         )
 
     def get_relationship_type(
-        self, relationship_type_id: int, *args, params: Optional[dict] = None, **kwargs
+        self,
+        relationship_type_id: int,
+        *args,
+        params: Optional[dict] = None,
+        **kwargs
     ):
         """
         Gets relationship type information for a specific relationship type id.

--- a/py_jama_client/apis/relationships_api.py
+++ b/py_jama_client/apis/relationships_api.py
@@ -113,7 +113,7 @@ class RelationshipsAPI:
         resource_path = "relationships/"
         headers = {"content-type": "application/json"}
         try:
-            response = self._core.post(
+            response = self.client.post(
                 resource_path,
                 params,
                 data=json.dumps(body),
@@ -149,7 +149,7 @@ class RelationshipsAPI:
         resource_path = "relationships/{}".format(relationship_id)
         headers = {"content-type": "application/json"}
         try:
-            response = self._core.put(
+            response = self.client.put(
                 resource_path, params, data=json.dumps(body), headers=headers, **kwargs
             )
         except CoreException as err:

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -159,3 +159,26 @@ class TagsAPI:
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return response.status_code
+
+    def get_tag_items(
+        self,
+        tag_id: int,
+        *args,
+        params: Optional[dict] = None,
+        allowed_results_per_page=DEFAULT_ALLOWED_RESULTS_PER_PAGE,
+        **kwargs,
+    ):
+        """
+        Get all items that have the tag with the specified id
+        Args:
+            allowed_results_per_page: Number of results per page
+
+        Returns: A Json Array containing all items tagged with the specified tag id.
+        """
+        resource_path = f"tags/{tag_id}/items"
+        return self.client.get_all(
+            resource_path,
+            params,
+            allowed_results_per_page=allowed_results_per_page,
+            **kwargs,
+        )

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -43,7 +43,8 @@ class TagsAPI:
             project: The API ID of the project to fetch tags for.
             allowed_results_per_page: Number of results per page
 
-        Returns: A Json Array that contains all the tag data for the specified project.
+        Returns: A Json Array that contains all the tag data for the specified
+        project.
 
         """
         req_params = {"project": project_id}
@@ -124,7 +125,8 @@ class TagsAPI:
         **kwargs,
     ):
         """
-        Update an existing tag with the specified tag ID in the project with the specified project ID
+        Update an existing tag with the specified tag ID in the project with
+        the specified project ID
         Args:
             tag_id: integer API id of the tag
             name: string name of the tag
@@ -135,7 +137,11 @@ class TagsAPI:
         headers = {"content-type": "application/json"}
         try:
             response = self.client.put(
-                resource_path, params, data=json.dumps(body), headers=headers, **kwargs
+                resource_path,
+                params,
+                data=json.dumps(body),
+                headers=headers,
+                **kwargs
             )
         except CoreException as err:
             py_jama_client_logger.error(err)
@@ -173,7 +179,8 @@ class TagsAPI:
         Args:
             allowed_results_per_page: Number of results per page
 
-        Returns: A Json Array containing all items tagged with the specified tag id.
+        Returns: A Json Array containing all items tagged with the specified
+        tag id.
         """
         resource_path = f"tags/{tag_id}/items"
         return self.client.get_all(

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -52,7 +52,7 @@ class TagsAPI:
         else:
             params.update(req_params)
 
-        return self.get_all(
+        return self.client.get_all(
             self.resource_path,
             params,
             allowed_results_per_page=allowed_results_per_page,

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -68,7 +68,7 @@ class TagsAPI:
         **kwargs,
     ):
         """
-        Create a new tag in the project with the specified ID
+        Create a new tag in the project with the specified project ID
         Args:
             name: The display name for the tag
             project: The project to create the new tag in

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -78,7 +78,7 @@ class TagsAPI:
         body = {"name": name, "project": project}
         headers = {"content-type": "application/json"}
         try:
-            response = self._core.post(
+            response = self.client.post(
                 self.resource_path,
                 params,
                 data=json.dumps(body),
@@ -107,7 +107,7 @@ class TagsAPI:
         """
         resource_path = f"tags/{tag_id}"
         try:
-            response = self._core.get(resource_path, params)
+            response = self.client.get(resource_path, params)
         except CoreException as err:
             py_jama_client_logger.error(err)
             raise APIException(str(err))
@@ -134,7 +134,7 @@ class TagsAPI:
         resource_path = "tags/{}".format(tag_id)
         headers = {"content-type": "application/json"}
         try:
-            response = self._core.put(
+            response = self.client.put(
                 resource_path, params, data=json.dumps(body), headers=headers, **kwargs
             )
         except CoreException as err:

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class TagsAPI:

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -142,3 +142,20 @@ class TagsAPI:
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
+
+    def delete_tag(self, tag_id: int) -> int:
+        """
+        Deletes a tag with the specified tag ID
+        Args:
+            tag_id: the api id of a tag
+
+        Returns: The success status code.
+        """
+        resource_path = f"tags/{tag_id}"
+        try:
+            response = self.client.delete(resource_path)
+        except CoreException as err:
+            py_jama_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.handle_response_status(response)
+        return response.status_code

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -113,3 +113,32 @@ class TagsAPI:
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
+
+    def put_tag(
+        self,
+        tag_id: int,
+        name: str,
+        project: int,
+        *args,
+        params: Optional[dict] = None,
+        **kwargs,
+    ):
+        """
+        Update an existing tag with the specified tag ID in the project with the specified project ID
+        Args:
+            tag_id: integer API id of the tag
+            name: string name of the tag
+            project: the project in which to update the tag
+        """
+        body = {"name": name, "project": project}
+        resource_path = "tags/{}".format(tag_id)
+        headers = {"content-type": "application/json"}
+        try:
+            response = self._core.put(
+                resource_path, params, data=json.dumps(body), headers=headers, **kwargs
+            )
+        except CoreException as err:
+            py_jama_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.handle_response_status(response)
+        return ClientResponse.from_response(response)

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -90,3 +90,26 @@ class TagsAPI:
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
+
+    def get_tag(
+        self,
+        tag_id: int,
+        *args,
+        params: Optional[dict] = None,
+        **kwargs,
+    ):
+        """
+        Gets item tag information for a specific item tag id.
+        Args:
+            item_tag_id: The api id of the item tag to fetch
+
+        Returns: JSON object
+        """
+        resource_path = f"tags/{tag_id}"
+        try:
+            response = self._core.get(resource_path, params)
+        except CoreException as err:
+            py_jama_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.handle_response_status(response)
+        return ClientResponse.from_response(response)

--- a/py_jama_client/apis/tags_api.py
+++ b/py_jama_client/apis/tags_api.py
@@ -3,7 +3,7 @@ Tags API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> tags_api = TagsAPI(client)
     >>> tags = tags_api.get_tags()

--- a/py_jama_client/apis/test_cycles_api.py
+++ b/py_jama_client/apis/test_cycles_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class TestCyclesAPI:

--- a/py_jama_client/apis/test_cycles_api.py
+++ b/py_jama_client/apis/test_cycles_api.py
@@ -3,7 +3,7 @@ Test Cycles API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> test_cycles_api = TestCyclesAPI(client)
     >>> test_cycles = test_cycles_api.get_test_cycles()

--- a/py_jama_client/apis/test_cycles_api.py
+++ b/py_jama_client/apis/test_cycles_api.py
@@ -37,7 +37,8 @@ class TestCyclesAPI:
         **kwargs,
     ):
         """
-        This method will return JSON data about the test cycle specified by the test cycle id.
+        This method will return JSON data about the test cycle specified by
+        the test cycle id.
 
         Args:
             test_cycle_id: the api id of the test cycle to fetch
@@ -63,8 +64,8 @@ class TestCyclesAPI:
         **kwargs,
     ):
         """
-        This method will return all test runs associated with the specified test cycle.  Test runs will be returned
-        as a list of json objects.
+        This method will return all test runs associated with the specified
+        test cycle.  Test runs will be returned as a list of json objects.
         Args:
             test_cycle_id: (int) The id of the test cycle
         """

--- a/py_jama_client/apis/test_plans_api.py
+++ b/py_jama_client/apis/test_plans_api.py
@@ -45,27 +45,35 @@ class TestPlansAPI:
         This method will create a new Test Cycle.
 
         Args:
-            testplan_id (int): The API_ID of the testplan to create the test cycle from.
-            testcycle_name (str): The name you would like to set for the new Test Cycle
+            testplan_id (int): The API_ID of the testplan to create the test
+                cycle from.
+            testcycle_name (str): The name you would like to set for the new
+                Test Cycle
             start_date (str): Start date in 'yyyy-mm-dd' Format
             end_date (str): End date in 'yyyy-mm-dd' Format
-            testgroups_to_include (int[]):  This array of integers specify the test groups to be included.
-            testrun_status_to_include (str[]): Only valid after generating the first Test Cycle, you may choose to only
-                generate Test Runs that were a specified status in the previous cycle. Do not specify anything to
-                include all statuses
+            testgroups_to_include (int[]):  This array of integers specify the
+                test groups to be included.
+            testrun_status_to_include (str[]): Only valid after generating the
+                first Test Cycle, you may choose to only generate Test Runs
+                that were a specified status in the previous cycle. Do not
+                specify anything to include all statuses
 
         Returns:
             (int): Returns the the newly created testcycle
         """
         resource_path = f"testplans/{testplan_id}/testcycles"
         headers = {"content-type": "application/json"}
-        fields = {"name": testcycle_name, "startDate": start_date, "endDate": end_date}
+        fields = {"name": testcycle_name,
+                  "startDate": start_date,
+                  "endDate": end_date}
         test_run_gen_config = {}
         if testgroups_to_include is not None:
             test_run_gen_config["testGroupsToInclude"] = testgroups_to_include
         if testrun_status_to_include is not None:
-            test_run_gen_config["testRunStatusesToInclude"] = testrun_status_to_include
-        body = {"fields": fields, "testRunGenerationConfig": test_run_gen_config}
+            test_run_gen_config["testRunStatusesToInclude"] = (
+                testrun_status_to_include)
+        body = {"fields": fields,
+                "testRunGenerationConfig": test_run_gen_config}
 
         # Make the API Call
         try:

--- a/py_jama_client/apis/test_plans_api.py
+++ b/py_jama_client/apis/test_plans_api.py
@@ -3,7 +3,7 @@ Test Plans API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> test_plans_api = TestPlansAPI(client)
     >>> test_plans = test_plans_api.get_test_plans()

--- a/py_jama_client/apis/test_plans_api.py
+++ b/py_jama_client/apis/test_plans_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class TestPlansAPI:

--- a/py_jama_client/apis/test_runs_api.py
+++ b/py_jama_client/apis/test_runs_api.py
@@ -3,7 +3,7 @@ Test Runs API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> test_runs_api = TestRunsAPI(client)
     >>> test_runs = test_runs_api.get_test_runs()

--- a/py_jama_client/apis/test_runs_api.py
+++ b/py_jama_client/apis/test_runs_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class TestRunsAPI:

--- a/py_jama_client/apis/users_api.py
+++ b/py_jama_client/apis/users_api.py
@@ -3,7 +3,7 @@ User API module
 
 Example usage:
 
-    >>> from py_jama_rest_client.client import JamaClient
+    >>> from py_jama_client.client import JamaClient
     >>> client = JamaClient(host=HOST, credentials=(USERNAME, PASSWORD))
     >>> users_api = UsersAPI(client)
     >>> users = users_api.get_users()

--- a/py_jama_client/apis/users_api.py
+++ b/py_jama_client/apis/users_api.py
@@ -116,8 +116,10 @@ class UsersAPI:
         Returns: JSON array
 
         """
+        resource_path = f"{self.resource_path}/current/favoritefilters"
+
         return self.client.get_all(
-            self.resource_path,
+            resource_path,
             params,
             allowed_results_per_page=allowed_results_per_page,
             **kwargs,

--- a/py_jama_client/apis/users_api.py
+++ b/py_jama_client/apis/users_api.py
@@ -127,7 +127,11 @@ class UsersAPI:
             phone: str - optional
             title: str - optional
             location: str - optional
-            licenseType: enum [ NAMED, FLOATING, STAKEHOLDER, FLOATING_COLLABORATOR, RESERVED_COLLABORATOR, FLOATING_REVIEWER, RESERVED_REVIEWER, NAMED_REVIEWER, TEST_RUNNER, EXPIRING_TRIAL, INACTIVE ]
+            licenseType: enum [ NAMED, FLOATING, STAKEHOLDER,
+                                FLOATING_COLLABORATOR,
+                                RESERVED_COLLABORATOR, FLOATING_REVIEWER,
+                                RESERVED_REVIEWER, NAMED_REVIEWER,
+                                TEST_RUNNER, EXPIRING_TRIAL, INACTIVE ]
 
         Returns: newly created user
 

--- a/py_jama_client/apis/users_api.py
+++ b/py_jama_client/apis/users_api.py
@@ -100,6 +100,29 @@ class UsersAPI:
             raise APIException(str(err))
         return ClientResponse.from_response(response)
 
+    def get_current_user_favorite_filters(
+        self,
+        *args,
+        params: Optional[dict] = None,
+        allowed_results_per_page=DEFAULT_ALLOWED_RESULTS_PER_PAGE,
+        **kwargs,
+    ):
+        """
+        Gets a list of favorite filters for the current user
+
+        Args:
+            allowed_results_per_page: Number of results per page
+
+        Returns: JSON array
+
+        """
+        return self.client.get_all(
+            self.resource_path,
+            params,
+            allowed_results_per_page=allowed_results_per_page,
+            **kwargs,
+        )
+
     def post_user(
         self,
         username: str,

--- a/py_jama_client/apis/users_api.py
+++ b/py_jama_client/apis/users_api.py
@@ -18,7 +18,7 @@ from py_jama_client.constants import DEFAULT_ALLOWED_RESULTS_PER_PAGE
 from py_jama_client.exceptions import APIException, CoreException
 from py_jama_client.response import ClientResponse
 
-py_jama_rest_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class UsersAPI:
@@ -76,7 +76,7 @@ class UsersAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         return ClientResponse.from_response(response)
 
@@ -96,7 +96,7 @@ class UsersAPI:
         try:
             response = self.client.get(resource_path, params, **kwargs)
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         return ClientResponse.from_response(response)
 
@@ -154,7 +154,7 @@ class UsersAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         JamaClient.handle_response_status(response)
         return ClientResponse.from_response(response)
@@ -212,7 +212,7 @@ class UsersAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         self.handle_response_status(response)
         return response.status_code
@@ -246,7 +246,7 @@ class UsersAPI:
                 **kwargs,
             )
         except CoreException as err:
-            py_jama_rest_client_logger.error(err)
+            py_jama_client_logger.error(err)
             raise APIException(str(err))
         self.handle_response_status(response)
         return response.status_code

--- a/py_jama_client/client.py
+++ b/py_jama_client/client.py
@@ -33,7 +33,7 @@ __DEBUG__ = False
 # disable warnings for ssl verification
 urllib3.disable_warnings()
 
-py_jama_client_logger = logging.getLogger("py_jama_rest_client")
+py_jama_client_logger = logging.getLogger("py_jama_client")
 
 
 class JamaClient:

--- a/py_jama_client/client.py
+++ b/py_jama_client/client.py
@@ -46,7 +46,8 @@ class JamaClient:
     def __init__(
         self,
         host: str,
-        credentials: Tuple[str, str] = ("username|client_id", "password|client_secret"),
+        credentials: Tuple[str, str] = ("username|client_id",
+                                        "password|client_secret"),
         api_version: str = "/rest/v1/",
         oauth: bool = False,
         verify: typing.Union[bool, str, ssl.SSLContext] = True,
@@ -55,13 +56,14 @@ class JamaClient:
         """
         Args:
             host: The host name of the Jama Connect server
-            credentials: A tuple of username and password or client_id and client_secret
+            credentials: A tuple of username and password or client_id and
+                client_secret
             api_version: The version of the Jama Connect API to use
-            oauth: A boolean to indicate if OAuth is being used. Must be set to true
-                if credentials are client id/secret pair.
-            verify: SSL certificates (a.k.a CA bundle) used to verify the identity of requested
-                hosts. Either True (default CA bundle), a path to an SSL certificate file, an
-                ssl.SSLContext, or False.
+            oauth: A boolean to indicate if OAuth is being used. Must be set
+                to true if credentials are client id/secret pair.
+            verify: SSL certificates (a.k.a CA bundle) used to verify the
+                identity of requested hosts. Either True (default CA bundle),
+                a path to an SSL certificate file, an ssl.SSLContext, or False.
             timeout: The timeout for the session
         """
         # Instance variables
@@ -92,10 +94,12 @@ class JamaClient:
         self.__session.close()
 
     async def close(self) -> None:
-        raise RuntimeError("await syntax not supported on sync core client class")
+        raise RuntimeError("await syntax not supported on sync core client"
+                           "class")
 
     def delete(self, resource: str, **kwargs):
-        """This method will perform a delete operation on the specified resource"""
+        """This method will perform a delete operation on the specified
+        resource"""
         url = self.__host_name + resource
 
         if self.__oauth:
@@ -106,7 +110,8 @@ class JamaClient:
         return self.__session.delete(url, auth=self.__credentials, **kwargs)
 
     def get(self, resource: str, params: dict = None, **kwargs):
-        """This method will perform a get operation on the specified resource"""
+        """This method will perform a get operation on the specified
+        resource"""
         url = self.__host_name + resource
 
         if self.__oauth:
@@ -114,10 +119,19 @@ class JamaClient:
             kwargs["headers"] = self.__add_auth_header(**kwargs)
             return self.__session.get(url, params=params, **kwargs)
 
-        return self.__session.get(url, auth=self.__credentials, params=params, **kwargs)
+        return self.__session.get(url,
+                                  auth=self.__credentials,
+                                  params=params,
+                                  **kwargs)
 
-    def patch(self, resource: str, params: dict = None, data=None, json=None, **kwargs):
-        """This method will perform a patch operation to the specified resource"""
+    def patch(self,
+              resource: str,
+              params: dict = None,
+              data=None,
+              json=None,
+              **kwargs):
+        """This method will perform a patch operation to the specified
+        resource"""
         url = self.__host_name + resource
 
         if self.__oauth:
@@ -128,11 +142,22 @@ class JamaClient:
             )
 
         return self.__session.patch(
-            url, auth=self.__credentials, params=params, data=data, json=json, **kwargs
+            url,
+            auth=self.__credentials,
+            params=params,
+            data=data,
+            json=json,
+            **kwargs
         )
 
-    def post(self, resource: str, params: dict = None, data=None, json=None, **kwargs):
-        """This method will perform a post operation to the specified resource."""
+    def post(self,
+             resource: str,
+             params: dict = None,
+             data=None,
+             json=None,
+             **kwargs):
+        """This method will perform a post operation to the specified
+        resource."""
         url = self.__host_name + resource
 
         if self.__oauth:
@@ -143,11 +168,22 @@ class JamaClient:
             )
 
         return self.__session.post(
-            url, auth=self.__credentials, params=params, data=data, json=json, **kwargs
+            url,
+            auth=self.__credentials,
+            params=params,
+            data=data,
+            json=json,
+            **kwargs
         )
 
-    def put(self, resource: str, params: dict = None, data=None, json=None, **kwargs):
-        """This method will perform a put operation to the specified resource"""
+    def put(self,
+            resource: str,
+            params: dict = None,
+            data=None,
+            json=None,
+            **kwargs):
+        """This method will perform a put operation to the specified
+        resource"""
         url = self.__host_name + resource
 
         if self.__oauth:
@@ -158,7 +194,12 @@ class JamaClient:
             )
 
         return self.__session.put(
-            url, auth=self.__credentials, data=data, params=params, json=json, **kwargs
+            url,
+            auth=self.__credentials,
+            data=data,
+            params=params,
+            json=json,
+            **kwargs
         )
 
     def __check_oauth_token(self):
@@ -173,10 +214,12 @@ class JamaClient:
                 self.__get_fresh_token()
 
     def __get_fresh_token(self):
-        """This method will fetch a new oauth bearer token from the oauth token server."""
+        """This method will fetch a new oauth bearer token from the oauth
+        token server."""
         data = {"grant_type": "client_credentials"}
 
-        # By getting the system time before we get the token we avoid a potential bug where the token may be expired.
+        # By getting the system time before we get the token we avoid a
+        # potential bug where the token may be expired.
         time_before_request = time.time()
 
         # Post to the token server, check if authorized
@@ -222,13 +265,15 @@ class JamaClient:
         **kwargs,
     ):
         """
-        This method will get all of the resources specified by the resource parameter, if an id or some other
-        parameter is required for the resource, include it in the params parameter.
+        This method will get all of the resources specified by the resource
+        parameter, if an id or some other parameter is required for the
+        resource, include it in the params parameter.
         Returns a single JSON array with all of the retrieved items.
         """
 
         if allowed_results_per_page < 1 or allowed_results_per_page > 50:
-            raise ValueError("Allowed results per page must be between 1 and 50")
+            raise ValueError("Allowed results per page must be between 1 "
+                             "and 50")
 
         start_index = 0
         allowed_results_per_page = 20
@@ -236,7 +281,10 @@ class JamaClient:
 
         data, meta, links, linked = [], {}, {}, {}
         while len(data) < total_results:
-            page = self.get_page(resource, start_index, params=params, **kwargs)
+            page = self.get_page(resource,
+                                 start_index,
+                                 params=params,
+                                 **kwargs)
 
             meta.update(page.meta)
             links.update(page.links)
@@ -250,7 +298,8 @@ class JamaClient:
                 }
 
             page_info = page.meta.get("pageInfo")
-            start_index = page_info.get("startIndex") + allowed_results_per_page
+            start_index = (page_info.get("startIndex") +
+                           allowed_results_per_page)
             total_results = page_info.get("totalResults")
             data.extend(page.data)
 
@@ -265,11 +314,13 @@ class JamaClient:
         **kwargs,
     ):
         """
-        This method will return one page of results from the specified resource type.
+        This method will return one page of results from the specified
+        resource type.
         Pass any needed parameters along
         The response object will be returned
         """
-        pagination = {"startAt": start_at, "maxResults": allowed_results_per_page}
+        pagination = {"startAt": start_at,
+                      "maxResults": allowed_results_per_page}
 
         if params is None:
             params = pagination
@@ -288,7 +339,8 @@ class JamaClient:
     def handle_response_status(response: Response):
         """
         Utility method for checking http status codes.
-        If the response code is not in the 200 range, An exception will be thrown.
+        If the response code is not in the 200 range, An exception will be
+        thrown.
         """
 
         status = response.status_code
@@ -297,7 +349,8 @@ class JamaClient:
             return status
 
         if status in range(400, 500):
-            """These are client errors. It is likely that something is wrong with the request."""
+            """These are client errors. It is likely that something is wrong
+            with the request."""
 
             response_message = "No Response"
 
@@ -315,7 +368,8 @@ class JamaClient:
                 )
             )
 
-            if response_message is not None and "already exists" in response_message:
+            if (response_message is not None and
+               "already exists" in response_message):
                 raise AlreadyExistsException(
                     "Entity already exists.",
                     status_code=status,
@@ -339,8 +393,8 @@ class JamaClient:
 
             if status == 429:
                 raise TooManyRequestsException(
-                    "Too many requests.  API throttling limit reached, or system under "
-                    "maintenance.",
+                    "Too many requests.  API throttling limit reached, or "
+                    "system under maintenance.",
                     status_code=status,
                     reason=response_message,
                 )
@@ -368,7 +422,10 @@ class JamaClient:
             )
 
         # Catch anything unexpected
-        py_jama_client_logger.error("{} error. {}".format(status, response.reason))
+        py_jama_client_logger.error("{} error. {}".format(status,
+                                                          response.reason))
         raise APIException(
-            "{} error".format(status), status_code=status, reason=response.reason
+            "{} error".format(status),
+            status_code=status,
+            reason=response.reason
         )

--- a/py_jama_client/exceptions.py
+++ b/py_jama_client/exceptions.py
@@ -8,7 +8,8 @@ class CoreException(Exception):
 
 
 class UnauthorizedTokenException(CoreException):
-    """This exception is thrown whenever fetching the oauth token returns a 401 unauthorized response."""
+    """This exception is thrown whenever fetching the oauth token returns a
+    401 unauthorized response."""
 
     pass
 
@@ -23,25 +24,29 @@ class APIException(Exception):
 
 
 class UnauthorizedException(APIException):
-    """This exception is thrown whenever the api returns a 401 unauthorized response."""
+    """This exception is thrown whenever the api returns a 401 unauthorized
+    response."""
 
     pass
 
 
 class TooManyRequestsException(APIException):
-    """This exception is thrown whenever the api returns a 429 too many requests response."""
+    """This exception is thrown whenever the api returns a 429 too many
+    requests response."""
 
     pass
 
 
 class ResourceNotFoundException(APIException):
-    """This exception is raised whenever the api returns a 404 not found response."""
+    """This exception is raised whenever the api returns a 404 not found
+    response."""
 
     pass
 
 
 class AlreadyExistsException(APIException):
-    """This exception is thrown when the API returns a 400 response with a message that the resource already exists."""
+    """This exception is thrown when the API returns a 400 response with a
+    message that the resource already exists."""
 
     pass
 
@@ -53,6 +58,7 @@ class APIClientException(APIException):
 
 
 class APIServerException(APIException):
-    """This exception is thrown whenever an unknown 500 response is encountered."""
+    """This exception is thrown whenever an unknown 500 response is
+    encountered."""
 
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 minversion = "7.0"
 testpaths = ["test"]
 env_files = ".env"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 minversion = "7.0"
 testpaths = ["test"]
-env_files = ".env"
+env_files = [".env"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,14 +7,23 @@ from py_jama_client.client import JamaClient
 from py_jama_client.response import ClientResponse
 
 
-@pytest.fixture(autouse=True)
-def env_vars():
-    if os.getenv("CLIENT_ID") is None and os.getenv("CLIENT_SECRET") is None:
+@pytest.fixture(autouse=True, scope="session")
+def connection_env_vars():
+    needed_evs = ['CLIENT_ID', 'CLIENT_SECRET', 'HOST']
+    missing_evs = [ev for ev in needed_evs if ev not in os.environ]
+    if len(missing_evs) > 0:
+        bulleted_ev_list = ('    - ' + 
+                       '\n                    - '.join(missing_evs))
+        if len(missing_evs) > 1:
+            singular_or_plural = 's'
+        else:
+            singular_or_plural = ''
         raise ValueError(
-            """
-                Please set environment variables 'client_id' and
-                'client_secret' to run tests properly.
-            """
+            f"""
+                Please set the following environment variable{singular_or_plural}
+                to run tests properly:
+                {bulleted_ev_list}
+            """    
         )
 
 
@@ -30,7 +39,7 @@ def get_test_jama_client():
         host=os.getenv("HOST"),
         credentials=(os.getenv("CLIENT_ID"), os.getenv("CLIENT_SECRET")),
         verify=ssl_context,
-        oauth=True,
+        oauth=False,
     )
 
     yield client

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,12 @@ import ssl
 
 import pytest
 
+from py_jama_client.apis.abstract_items_api import AbstractItemsAPI
+from py_jama_client.apis.baselines_api import BaselinesAPI
+from py_jama_client.apis.item_types_api import ItemTypesAPI
+from py_jama_client.apis.projects_api import ProjectsAPI
+from py_jama_client.apis.relationships_api import RelationshipsAPI
+from py_jama_client.apis.tags_api import TagsAPI
 from py_jama_client.client import JamaClient
 from py_jama_client.response import ClientResponse
 
@@ -136,3 +142,145 @@ def get_example_client_response():
             },
         ],
     )
+
+
+@pytest.fixture(scope="session")
+def real_abstract_item(get_test_jama_client, real_project, real_item_type):
+    if 'ABSTRACT_ITEM_ID' in os.environ:
+        return os.environ.get('ABSTRACT_ITEM_ID')
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    abstract_items = abstract_items_api.get_abstract_items(
+        project=(real_project,),
+        item_type=(real_item_type,)).data
+    if abstract_items == []:
+        raise ValueError(
+            """
+                Unable to identify a viable abstract item for sample testing
+            """)    
+    else:
+        return abstract_items[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_abstract_item_version(get_test_jama_client, real_abstract_item):
+    if 'ABSTRACT_ITEM_VERSION' in os.environ:
+        return os.environ.get('ABSTRACT_ITEM_VERSION')
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    abstract_item_versions = abstract_items_api.get_abstract_item_versions(
+        item_id=real_abstract_item).data
+    if abstract_item_versions == []:
+        raise ValueError(
+            """
+                Unable to identify a viable abstract item for sample
+                version testing
+            """)    
+    else:
+        return abstract_item_versions[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_baseline(get_test_jama_client, real_project):
+    if 'BASELINE_ID' in os.environ:
+        return os.environ.get('BASELINE_ID')
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    baselines = baselines_api.get_baselines(project_id=real_project).data
+    if baselines == []:
+        raise ValueError(
+            """
+                Unable to identify a viable baseline for sample testing
+            """)    
+    else:
+        return baselines[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_baseline_versioned_item(get_test_jama_client, real_baseline):
+    if 'BASELINE_ID' in os.environ:
+        return os.environ.get('BASELINE_ID')
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    baseline_versioned_items = baselines_api.get_baseline_versioned_items(
+        baseline_id=real_baseline).data
+    if baseline_versioned_items == []:
+        raise ValueError(
+            """
+                Unable to identify a viable baseline for sample testing
+            """)    
+    else:
+        return baseline_versioned_items[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_project(get_test_jama_client):
+    if 'PROJECT_ID' in os.environ:
+        return os.environ.get('PROJECT_ID')
+    projects_api = ProjectsAPI(get_test_jama_client)
+    projects = projects_api.get_projects().data
+    if projects == []:
+        raise ValueError(
+            """
+                Unable to identify a viable project for sample testing
+            """)    
+    # return projects[0]['id']
+    else:
+        return 350
+
+
+@pytest.fixture(scope="session")
+def real_item_type(get_test_jama_client):
+    if 'ITEM_TYPE_ID' in os.environ:
+        return os.environ.get('ITEM_TYPE_ID')
+    item_types_api = ItemTypesAPI(get_test_jama_client)
+    item_types = item_types_api.get_item_types().data
+    if item_types == []:
+        raise ValueError(
+            """
+                Unable to identify a viable item type for sample testing
+            """)    
+    else:
+        return item_types[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_relationship(get_test_jama_client, real_project):
+    if 'RELATIONSHIP_ID' in os.environ:
+        return os.environ.get('RELATIONSHIP_ID')
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    relationships = relationships_api.get_relationships(
+        project_id=real_project).data
+    if relationships == []:
+        raise ValueError(
+            """
+                Unable to identify a viable relationship for sample testing
+            """)    
+    else:
+        return relationships[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_relationship_type(get_test_jama_client):
+    if 'RELATIONSHIP_TYPE_ID' in os.environ:
+        return os.environ.get('RELATIONSHIP_TYPE_ID')
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    relationship_types = relationships_api.get_relationship_types().data
+    if relationship_types == []:
+        raise ValueError(
+            """
+                Unable to identify a viable relationship type for sample testing
+            """)    
+    else:
+        return relationship_types[0]['id']
+
+
+@pytest.fixture(scope="session")
+def real_tag(get_test_jama_client, real_project):
+    if 'TAG_ID' in os.environ:
+        return os.environ.get('TAG_ID')
+    tags_api = TagsAPI(get_test_jama_client)
+    tags = tags_api.get_tags(project_id=real_project).data
+    if tags == []:
+        raise ValueError(
+            """
+                Unable to identify a viable tag for sample testing
+            """)    
+    else:
+        return tags[0]['id']

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,6 +9,7 @@ from py_jama_client.apis.item_types_api import ItemTypesAPI
 from py_jama_client.apis.projects_api import ProjectsAPI
 from py_jama_client.apis.relationships_api import RelationshipsAPI
 from py_jama_client.apis.tags_api import TagsAPI
+from py_jama_client.apis.users_api import UsersAPI
 from py_jama_client.client import JamaClient
 from py_jama_client.response import ClientResponse
 
@@ -284,3 +285,10 @@ def real_tag(get_test_jama_client, real_project):
             """)    
     else:
         return tags[0]['id']
+
+
+@pytest.fixture(scope="session")
+def current_user(get_test_jama_client):
+    users_api = UsersAPI(get_test_jama_client)
+    user = users_api.get_current_user().data
+    yield user

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -175,7 +175,7 @@ def real_abstract_item_version(get_test_jama_client, real_abstract_item):
                 version testing
             """)    
     else:
-        return abstract_item_versions[0]['id']
+        return abstract_item_versions[0]['versionNumber']
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,8 +12,8 @@ def env_vars():
     if os.getenv("CLIENT_ID") is None and os.getenv("CLIENT_SECRET") is None:
         raise ValueError(
             """
-                Please set environment variables 'client_id' and 'client_secret' 
-                to run tests properly.
+                Please set environment variables 'client_id' and
+                'client_secret' to run tests properly.
             """
         )
 
@@ -42,20 +42,26 @@ def get_example_client_response():
         meta={
             "status": "OK",
             "timestamp": "2024-01-24T14:19:40.043+0000",
-            "pageInfo": {"startIndex": 0, "resultCount": 20, "totalResults": 515},
+            "pageInfo": {"startIndex": 0,
+                         "resultCount": 20,
+                         "totalResults": 515},
         },
         links={
             "data.itemType": {
                 "type": "itemtypes",
-                "href": "https://silabs.jamacloud.com/rest/v1/itemtypes/{data.itemType}",
+                "href": ("https://silabs.jamacloud.com/rest/v1/itemtypes/"
+                         "{data.itemType}"),
             },
             "data.location.parent.project": {
                 "type": "projects",
-                "href": "https://silabs.jamacloud.com/rest/v1/projects/{data.location.parent.project}",
+                "href": ("https://silabs.jamacloud.com/rest/v1/projects/"
+                         "{data.location.parent.project}"),
             },
             "data.fields.verification_method$141": {
                 "type": "picklistoptions",
-                "href": "https://silabs.jamacloud.com/rest/v1/picklistoptions/{data.fields.verification_method$141}",
+                "href": ("https://silabs.jamacloud.com/rest/v1/"
+                         "picklistoptions/"
+                         "{data.fields.verification_method$141}"),
             },
         },
         linked={"test": "linked"},
@@ -77,7 +83,8 @@ def get_example_client_response():
                     "name": "Security Requirments",
                     "description": "",
                 },
-                "resources": {"self": {"allowed": ["GET", "PUT", "PATCH", "DELETE"]}},
+                "resources": {"self": {
+                    "allowed": ["GET", "PUT", "PATCH", "DELETE"]}},
                 "location": {
                     "sortOrder": 0,
                     "globalSortOrder": 4902930,
@@ -106,7 +113,8 @@ def get_example_client_response():
                     "description": "",
                     "document_status$31": 566,
                 },
-                "resources": {"self": {"allowed": ["GET", "PUT", "PATCH", "DELETE"]}},
+                "resources": {"self": {
+                    "allowed": ["GET", "PUT", "PATCH", "DELETE"]}},
                 "location": {
                     "sortOrder": 0,
                     "globalSortOrder": 9805860,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -221,9 +221,9 @@ def real_project(get_test_jama_client):
             """
                 Unable to identify a viable project for sample testing
             """)    
-    # return projects[0]['id']
     else:
-        return 350
+        # return 350
+        return projects[0]['id']
 
 
 @pytest.fixture(scope="session")

--- a/test/test_abstract_items_api.py
+++ b/test/test_abstract_items_api.py
@@ -3,5 +3,6 @@ from py_jama_client.apis.abstract_items_api import AbstractItemsAPI
 
 def test_get_abstract_item(get_test_jama_client):
     abstract_items_api = AbstractItemsAPI(get_test_jama_client)
-    response = abstract_items_api.get_abstract_items(project=(195,), item_type=(193,))
+    response = abstract_items_api.get_abstract_items(project=(195,),
+                                                     item_type=(193,))
     assert response.data != []

--- a/test/test_abstract_items_api.py
+++ b/test/test_abstract_items_api.py
@@ -1,8 +1,45 @@
 from py_jama_client.apis.abstract_items_api import AbstractItemsAPI
 
 
-def test_get_abstract_item(get_test_jama_client):
+def test_get_abstract_items(get_test_jama_client,
+                           real_project,
+                           real_item_type):
     abstract_items_api = AbstractItemsAPI(get_test_jama_client)
-    response = abstract_items_api.get_abstract_items(project=(195,),
-                                                     item_type=(193,))
+    response = abstract_items_api.get_abstract_items(
+        project=(real_project,),
+        item_type=(real_item_type,))
+    assert response.data != []
+
+
+def test_get_abstract_item(get_test_jama_client,
+                           real_abstract_item):
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    response = abstract_items_api.get_abstract_item(item_id=real_abstract_item)
+    assert response.data != []
+
+
+def test_get_abstract_item_versions(get_test_jama_client,
+                                    real_abstract_item):
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    response = abstract_items_api.get_abstract_item_versions(
+        item_id=real_abstract_item)
+    assert response.data != []
+
+def test_get_abstract_item_version(get_test_jama_client,
+                                   real_abstract_item,
+                                   real_abstract_item_version):
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    response = abstract_items_api.get_abstract_item_version(
+        item_id=real_abstract_item,
+        version_num=real_abstract_item_version)
+    assert response.data != []
+
+
+def test_get_abstract_versioned_item(get_test_jama_client,
+                                     real_abstract_item,
+                                     real_abstract_item_version):
+    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+    response = abstract_items_api.get_abstract_versioned_item(
+        item_id=real_abstract_item,
+        version_num=real_abstract_item_version)
     assert response.data != []

--- a/test/test_abstract_items_api.py
+++ b/test/test_abstract_items_api.py
@@ -1,44 +1,45 @@
 from py_jama_client.apis.abstract_items_api import AbstractItemsAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def abstract_items_api(get_test_jama_client):
+    api_instance = AbstractItemsAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_abstract_items(get_test_jama_client,
-                           real_project,
-                           real_item_type):
-    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
+def test_get_abstract_items(abstract_items_api,
+                            real_project,
+                            real_item_type):
     response = abstract_items_api.get_abstract_items(
         project=(real_project,),
         item_type=(real_item_type,))
     assert response.data != []
 
 
-def test_get_abstract_item(get_test_jama_client,
+def test_get_abstract_item(abstract_items_api,
                            real_abstract_item):
-    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
     response = abstract_items_api.get_abstract_item(item_id=real_abstract_item)
     assert response.data != []
 
 
-def test_get_abstract_item_versions(get_test_jama_client,
+def test_get_abstract_item_versions(abstract_items_api,
                                     real_abstract_item):
-    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
     response = abstract_items_api.get_abstract_item_versions(
         item_id=real_abstract_item)
     assert response.data != []
 
-def test_get_abstract_item_version(get_test_jama_client,
+def test_get_abstract_item_version(abstract_items_api,
                                    real_abstract_item,
                                    real_abstract_item_version):
-    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
     response = abstract_items_api.get_abstract_item_version(
         item_id=real_abstract_item,
         version_num=real_abstract_item_version)
     assert response.data != []
 
 
-def test_get_abstract_versioned_item(get_test_jama_client,
+def test_get_abstract_versioned_item(abstract_items_api,
                                      real_abstract_item,
                                      real_abstract_item_version):
-    abstract_items_api = AbstractItemsAPI(get_test_jama_client)
     response = abstract_items_api.get_abstract_versioned_item(
         item_id=real_abstract_item,
         version_num=real_abstract_item_version)

--- a/test/test_baselines_api.py
+++ b/test/test_baselines_api.py
@@ -1,16 +1,57 @@
 from py_jama_client.apis.baselines_api import BaselinesAPI
 
 
-def test_get_baselines(get_test_jama_client):
+def test_get_baselines(get_test_jama_client, real_project):
     baselines_api = BaselinesAPI(get_test_jama_client)
-    response = baselines_api.get_baselines(project_id=82)
+    response = baselines_api.get_baselines(project_id=real_project)
     assert response.data is not None
 
 
-def test_get_baselines_with_link(get_test_jama_client):
+def test_get_baseline(get_test_jama_client, real_baseline):
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    response = baselines_api.get_baseline(baseline_id=real_baseline)
+    assert response.data is not None
+
+
+def test_get_baseline_review_link(get_test_jama_client, real_baseline):
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    response = baselines_api.get_baseline_review_link(
+        baseline_id=real_baseline)
+    assert response.data is not None
+
+
+def test_get_baseline_versioned_items(get_test_jama_client, real_baseline):
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    response = baselines_api.get_baseline_versioned_items(
+        baseline_id=real_baseline)
+    assert response.data is not None
+
+
+def test_get_baseline_versioned_item(get_test_jama_client,
+                                     real_baseline,
+                                     real_baseline_versioned_item):
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    response = baselines_api.get_baseline_versioned_item(
+        baseline_id=real_baseline,
+        item_id=real_baseline_versioned_item)
+    assert response.data is not None
+
+
+def test_get_baseline_versioned_item_relationships(
+        get_test_jama_client,
+        real_baseline,
+        real_baseline_versioned_item):
+    baselines_api = BaselinesAPI(get_test_jama_client)
+    response = baselines_api.get_baseline_versioned_item_relationships(
+        baseline_id=real_baseline,
+        item_id=real_baseline_versioned_item)
+    assert response.data is not None
+
+
+def test_get_baselines_with_link(get_test_jama_client, real_project):
     baselines_api = BaselinesAPI(get_test_jama_client)
     response = baselines_api.get_baselines(
-        project_id=82,
+        project_id=real_project,
         params={"include": ("data.project", "data.createdBy")},
     )
     assert len(response.linked) > 0

--- a/test/test_baselines_api.py
+++ b/test/test_baselines_api.py
@@ -1,36 +1,37 @@
 from py_jama_client.apis.baselines_api import BaselinesAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def baselines_api(get_test_jama_client):
+    api_instance = BaselinesAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_baselines(get_test_jama_client, real_project):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+def test_get_baselines(baselines_api, real_project):
     response = baselines_api.get_baselines(project_id=real_project)
     assert response.data is not None
 
 
-def test_get_baseline(get_test_jama_client, real_baseline):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+def test_get_baseline(baselines_api, real_baseline):
     response = baselines_api.get_baseline(baseline_id=real_baseline)
     assert response.data is not None
 
 
-def test_get_baseline_review_link(get_test_jama_client, real_baseline):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+def test_get_baseline_review_link(baselines_api, real_baseline):
     response = baselines_api.get_baseline_review_link(
         baseline_id=real_baseline)
     assert response.data is not None
 
 
-def test_get_baseline_versioned_items(get_test_jama_client, real_baseline):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+def test_get_baseline_versioned_items(baselines_api, real_baseline):
     response = baselines_api.get_baseline_versioned_items(
         baseline_id=real_baseline)
     assert response.data is not None
 
 
-def test_get_baseline_versioned_item(get_test_jama_client,
+def test_get_baseline_versioned_item(baselines_api,
                                      real_baseline,
                                      real_baseline_versioned_item):
-    baselines_api = BaselinesAPI(get_test_jama_client)
     response = baselines_api.get_baseline_versioned_item(
         baseline_id=real_baseline,
         item_id=real_baseline_versioned_item)
@@ -38,18 +39,16 @@ def test_get_baseline_versioned_item(get_test_jama_client,
 
 
 def test_get_baseline_versioned_item_relationships(
-        get_test_jama_client,
-        real_baseline,
-        real_baseline_versioned_item):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+                                        baselines_api,
+                                        real_baseline,
+                                        real_baseline_versioned_item):
     response = baselines_api.get_baseline_versioned_item_relationships(
         baseline_id=real_baseline,
         item_id=real_baseline_versioned_item)
     assert response.data is not None
 
 
-def test_get_baselines_with_link(get_test_jama_client, real_project):
-    baselines_api = BaselinesAPI(get_test_jama_client)
+def test_get_baselines_with_link(baselines_api, real_project):
     response = baselines_api.get_baselines(
         project_id=real_project,
         params={"include": ("data.project", "data.createdBy")},

--- a/test/test_item_types.py
+++ b/test/test_item_types.py
@@ -1,0 +1,13 @@
+from py_jama_client.apis.item_types_api import ItemTypesAPI
+
+
+def test_get_item_types(get_test_jama_client):
+    item_types_api = ItemTypesAPI(get_test_jama_client)
+    response = item_types_api.get_item_types()
+    assert response.data != []
+
+
+def test_get_tag(get_test_jama_client):
+    item_types_api = ItemTypesAPI(get_test_jama_client)
+    response = item_types_api.get_item_type(item_type_id=1)
+    assert response.data is not None

--- a/test/test_item_types_api.py
+++ b/test/test_item_types_api.py
@@ -7,7 +7,7 @@ def test_get_item_types(get_test_jama_client):
     assert response.data != []
 
 
-def test_get_tag(get_test_jama_client):
+def test_get_item_type(get_test_jama_client, real_item_type):
     item_types_api = ItemTypesAPI(get_test_jama_client)
-    response = item_types_api.get_item_type(item_type_id=1)
+    response = item_types_api.get_item_type(item_type_id=real_item_type)
     assert response.data is not None

--- a/test/test_item_types_api.py
+++ b/test/test_item_types_api.py
@@ -1,13 +1,17 @@
 from py_jama_client.apis.item_types_api import ItemTypesAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def item_types_api(get_test_jama_client):
+    api_instance = ItemTypesAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_item_types(get_test_jama_client):
-    item_types_api = ItemTypesAPI(get_test_jama_client)
+def test_get_item_types(item_types_api):
     response = item_types_api.get_item_types()
     assert response.data != []
 
 
-def test_get_item_type(get_test_jama_client, real_item_type):
-    item_types_api = ItemTypesAPI(get_test_jama_client)
+def test_get_item_type(item_types_api, real_item_type):
     response = item_types_api.get_item_type(item_type_id=real_item_type)
     assert response.data is not None

--- a/test/test_projects_api.py
+++ b/test/test_projects_api.py
@@ -1,13 +1,17 @@
 from py_jama_client.apis.projects_api import ProjectsAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def projects_api(get_test_jama_client):
+    api_instance = ProjectsAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_projects(get_test_jama_client):
-    projects_api = ProjectsAPI(get_test_jama_client)
+def test_get_projects(projects_api):
     response = projects_api.get_projects()
     assert response.data != []
 
 
-def test_get_project_by_id(get_test_jama_client, real_project):
-    projects_api = ProjectsAPI(get_test_jama_client)
+def test_get_project_by_id(projects_api, real_project):
     response = projects_api.get_project_by_id(project_id=real_project)
     assert response.data is not None

--- a/test/test_projects_api.py
+++ b/test/test_projects_api.py
@@ -1,0 +1,13 @@
+from py_jama_client.apis.projects_api import ProjectsAPI
+
+
+def test_get_projects(get_test_jama_client):
+    projects_api = ProjectsAPI(get_test_jama_client)
+    response = projects_api.get_projects()
+    assert response.data != []
+
+
+def test_get_project_by_id(get_test_jama_client, real_project):
+    projects_api = ProjectsAPI(get_test_jama_client)
+    response = projects_api.get_project_by_id(project_id=real_project)
+    assert response.data is not None

--- a/test/test_relationships_api.py
+++ b/test/test_relationships_api.py
@@ -1,28 +1,30 @@
 from py_jama_client.apis.relationships_api import RelationshipsAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def relationships_api(get_test_jama_client):
+    api_instance = RelationshipsAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_relationships(get_test_jama_client, real_project):
-    relationships_api = RelationshipsAPI(get_test_jama_client)
+def test_get_relationships(relationships_api, real_project):
     response = relationships_api.get_relationships(
         project_id=real_project)
     assert response.data != []
 
 
-def test_get_relationship(get_test_jama_client, real_relationship):
-    relationships_api = RelationshipsAPI(get_test_jama_client)
+def test_get_relationship(relationships_api, real_relationship):
     response = relationships_api.get_relationship(
         relationship_id=real_relationship)
     assert response.data != []
 
 
-def test_get_relationship_types(get_test_jama_client):
-    relationships_api = RelationshipsAPI(get_test_jama_client)
+def test_get_relationship_types(relationships_api):
     response = relationships_api.get_relationship_types()
     assert response.data != []
 
 
-def test_get_relationship_type(get_test_jama_client, real_relationship_type):
-    relationships_api = RelationshipsAPI(get_test_jama_client)
+def test_get_relationship_type(relationships_api, real_relationship_type):
     response = relationships_api.get_relationship_type(
         relationship_type_id=real_relationship_type)
     assert response.data != []

--- a/test/test_relationships_api.py
+++ b/test/test_relationships_api.py
@@ -1,0 +1,28 @@
+from py_jama_client.apis.relationships_api import RelationshipsAPI
+
+
+def test_get_relationships(get_test_jama_client, real_project):
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    response = relationships_api.get_relationships(
+        project_id=real_project)
+    assert response.data != []
+
+
+def test_get_relationship(get_test_jama_client, real_relationship):
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    response = relationships_api.get_relationship(
+        relationship_id=real_relationship)
+    assert response.data != []
+
+
+def test_get_relationship_types(get_test_jama_client):
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    response = relationships_api.get_relationship_types()
+    assert response.data != []
+
+
+def test_get_relationship_type(get_test_jama_client, real_relationship_type):
+    relationships_api = RelationshipsAPI(get_test_jama_client)
+    response = relationships_api.get_relationship_type(
+        relationship_type_id=real_relationship_type)
+    assert response.data != []

--- a/test/test_tags_api.py
+++ b/test/test_tags_api.py
@@ -1,19 +1,19 @@
 from py_jama_client.apis.tags_api import TagsAPI
 
 
-def test_get_tags(get_test_jama_client):
+def test_get_tags(get_test_jama_client, real_project):
     tags_api = TagsAPI(get_test_jama_client)
-    response = tags_api.get_tags(project_id=195)
+    response = tags_api.get_tags(project_id=real_project)
     assert response.data != []
 
 
-def test_get_tag(get_test_jama_client):
+def test_get_tag(get_test_jama_client, real_tag):
     tags_api = TagsAPI(get_test_jama_client)
-    response = tags_api.get_tag(tag_id=1)
+    response = tags_api.get_tag(tag_id=real_tag)
     assert response.data is not None
 
 
-def test_get_tag_items(get_test_jama_client):
+def test_get_tag_items(get_test_jama_client, real_tag):
     tags_api = TagsAPI(get_test_jama_client)
-    response = tags_api.get_tag_items(tag_id=1)
+    response = tags_api.get_tag_items(tag_id=real_tag)
     assert response.data != []

--- a/test/test_tags_api.py
+++ b/test/test_tags_api.py
@@ -1,19 +1,22 @@
 from py_jama_client.apis.tags_api import TagsAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def tags_api(get_test_jama_client):
+    api_instance = TagsAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_tags(get_test_jama_client, real_project):
-    tags_api = TagsAPI(get_test_jama_client)
+def test_get_tags(tags_api, real_project):
     response = tags_api.get_tags(project_id=real_project)
     assert response.data != []
 
 
-def test_get_tag(get_test_jama_client, real_tag):
-    tags_api = TagsAPI(get_test_jama_client)
+def test_get_tag(tags_api, real_tag):
     response = tags_api.get_tag(tag_id=real_tag)
     assert response.data is not None
 
 
-def test_get_tag_items(get_test_jama_client, real_tag):
-    tags_api = TagsAPI(get_test_jama_client)
+def test_get_tag_items(tags_api, real_tag):
     response = tags_api.get_tag_items(tag_id=real_tag)
     assert response.data != []

--- a/test/test_tags_api.py
+++ b/test/test_tags_api.py
@@ -1,0 +1,19 @@
+from py_jama_client.apis.tags_api import TagsAPI
+
+
+def test_get_tags(get_test_jama_client):
+    tags_api = TagsAPI(get_test_jama_client)
+    response = tags_api.get_tags(project_id=195)
+    assert response.data != []
+
+
+def test_get_tag(get_test_jama_client):
+    tags_api = TagsAPI(get_test_jama_client)
+    response = tags_api.get_tag(tag_id=1)
+    assert response.data is not None
+
+
+def test_get_tag_items(get_test_jama_client):
+    tags_api = TagsAPI(get_test_jama_client)
+    response = tags_api.get_tag_items(tag_id=1)
+    assert response.data != []

--- a/test/test_users_api.py
+++ b/test/test_users_api.py
@@ -7,7 +7,72 @@ def test_get_current_user(get_test_jama_client):
     assert user.data is not None
 
 
+def test_get_current_user_favorite_filters(get_test_jama_client):
+    users_api = UsersAPI(get_test_jama_client)
+    user = users_api.get_current_user()
+    assert user.data is not None
+
+
 def test_get_users(get_test_jama_client):
     users_api = UsersAPI(get_test_jama_client)
     response = users_api.get_users()
     assert response.data is not None
+
+
+def test_get_users_by_project(get_test_jama_client, real_project):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params=
+                                   {"project": real_project})
+    assert response.data is not None
+
+
+def test_get_users_by_username(get_test_jama_client, real_project, current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params={
+                                   "project": real_project,
+                                   "username": current_user['username']})
+    assert current_user in response.data
+
+
+def test_get_users_by_email(get_test_jama_client, real_project, current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params={
+                                   "project": real_project,
+                                   "email": current_user['email']})
+    assert current_user in response.data
+
+
+def test_get_users_by_first_name(get_test_jama_client,
+                                 real_project,
+                                 current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params={
+                                           "project": real_project,
+                                           "firstName": current_user['firstName']})
+    assert current_user in response.data
+
+
+def test_get_users_by_last_name(get_test_jama_client,
+                                real_project,
+                                current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params={
+                                           "project": real_project,
+                                           "lastName": current_user['lastName']})
+    assert current_user in response.data
+
+
+def test_get_users_by_license_type(get_test_jama_client,
+                                   real_project,
+                                   current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_users(params={
+                                           "project": real_project,
+                                           "licenseType": current_user['licenseType']})
+    assert current_user in response.data
+
+
+def test_get_user(get_test_jama_client, current_user):
+    users_api = UsersAPI(get_test_jama_client)
+    response = users_api.get_user(user_id=current_user['id'])
+    assert current_user == response.data

--- a/test/test_users_api.py
+++ b/test/test_users_api.py
@@ -1,78 +1,67 @@
 from py_jama_client.apis.users_api import UsersAPI
+import pytest
+
+@pytest.fixture(scope="function")
+def users_api(get_test_jama_client):
+    api_instance = UsersAPI(get_test_jama_client)
+    return api_instance
 
 
-def test_get_current_user(get_test_jama_client):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_current_user(users_api):
     user = users_api.get_current_user()
     assert user.data is not None
 
 
-def test_get_current_user_favorite_filters(get_test_jama_client):
-    users_api = UsersAPI(get_test_jama_client)
-    user = users_api.get_current_user()
-    assert user.data is not None
+def test_get_current_user_favorite_filters(users_api):
+    filters = users_api.get_current_user_favorite_filters()
+    assert filters.data is not None
 
-
-def test_get_users(get_test_jama_client):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users(users_api):
     response = users_api.get_users()
     assert response.data is not None
 
 
-def test_get_users_by_project(get_test_jama_client, real_project):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_project(users_api, real_project):
     response = users_api.get_users(params=
                                    {"project": real_project})
     assert response.data is not None
 
 
-def test_get_users_by_username(get_test_jama_client, real_project, current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_username(users_api, real_project, current_user):
     response = users_api.get_users(params={
                                    "project": real_project,
                                    "username": current_user['username']})
     assert current_user in response.data
 
 
-def test_get_users_by_email(get_test_jama_client, real_project, current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_email(users_api, real_project, current_user):
     response = users_api.get_users(params={
                                    "project": real_project,
                                    "email": current_user['email']})
     assert current_user in response.data
 
 
-def test_get_users_by_first_name(get_test_jama_client,
-                                 real_project,
-                                 current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_first_name(users_api, real_project, current_user):
     response = users_api.get_users(params={
                                            "project": real_project,
                                            "firstName": current_user['firstName']})
     assert current_user in response.data
 
 
-def test_get_users_by_last_name(get_test_jama_client,
-                                real_project,
-                                current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_last_name(users_api, real_project, current_user):
     response = users_api.get_users(params={
                                            "project": real_project,
                                            "lastName": current_user['lastName']})
     assert current_user in response.data
 
 
-def test_get_users_by_license_type(get_test_jama_client,
-                                   real_project,
-                                   current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_users_by_license_type(users_api, real_project, current_user):
     response = users_api.get_users(params={
                                            "project": real_project,
                                            "licenseType": current_user['licenseType']})
     assert current_user in response.data
 
 
-def test_get_user(get_test_jama_client, current_user):
-    users_api = UsersAPI(get_test_jama_client)
+def test_get_user(users_api, current_user):
     response = users_api.get_user(user_id=current_user['id'])
     assert current_user == response.data


### PR DESCRIPTION
Proposing an omnibus update to my version 0.1.0 of the library.

Changes
* Breaking
  * `AbstractItemsAPI`
    * `get_abtract_item_version()`: corrected to `get_abstract_item_version()`
  * `RelationshipsAPI`
    * `get_relationship_rule_set()`: renamed `id` parameter to `relationship_id`
    * `delete_relationships()`: renamed to `delete_relationship()`
  * logger renamed to match current library named (dropped the _rest_)
* Additions
  * `RelationshipsAPI`
    * `delete_relationship_suspect()`
  * `TagsAPI`
    * `get_tag()`
    * `put_tag()`
    * `delete_tag()`
    * `get_tag_items()
  * `UsersAPI`
    * `get_current_user_favorite_filters()`
* Bugfixes
  * `get_baseline_versioned_items()` uses unpaged response
  * multiple places: remove outdated references to _core.get, _core.put
* Clerical
  * Dropped _rest_ in from references in README
  * Fixed many incorrect references in comment headers of api files
  * 80 character lines for Flake8
  * Rephrase a few imprecise internal docstrings
* Test
  * Made HOST a required env var
  * Added fixtures to use env var or pick a candidate ID for many sample objects to test against
  * Numerous new test for various get functions including new test modules for
    * item_types
    * projects
    * relationships
    * tags
  * Reduced duplication within each test module with an API instance fixture
